### PR TITLE
Fix small LaTeX display bug

### DIFF
--- a/FockSystem/FockSystem.py
+++ b/FockSystem/FockSystem.py
@@ -398,8 +398,9 @@ class OperSequence(FockSystemBase):
             else:
                 operstr += " $+$ " + f"{w*oper_seq}"
         if operstr[0:4] == " $+$":
-            return operstr[4:]
-        return operstr
+            return operstr[4:].replace("$$", "") 
+        return operstr.replace("$$", "") # ending mathmode and starting it right after again confuses the renderer
+        
         
     def symbolic(self) -> None:
         operstr = ""


### PR DESCRIPTION

Maybe just on my side but the double math mode generated by the repr method sometimes caused the latex to be rendered incorrectly

Before :

![image](https://github.com/user-attachments/assets/072a425c-ad98-413c-8834-74f0aeae2cf9)

After : 

![image](https://github.com/user-attachments/assets/5dd0658c-1a09-404a-8213-f84a4b8b4da4)

